### PR TITLE
Behave correctly when object keys are numeric, particularly when the key is the falsey value '0'

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ function Model(data) {
  * @api public
  */
 proto.get = function(key) {
-  return key
+  return key !== undefined && key !== false
     ? this._data[key]
     : this._data;
 };

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "license": "MIT",
   "readmeFilename": "README.md",
   "scripts": {
-    "test": "./node_modules/.bin/grunt buster"
+    "test": "./node_modules/.bin/grunt && ./node_modules/.bin/grunt buster"
   },
   "gitHead": "ef12b4cdd358fd5dfcab16a3328dfacf9e636027",
   "dependencies": {

--- a/test/model.get.js
+++ b/test/model.get.js
@@ -24,5 +24,14 @@ buster.testCase('Model#get()', {
     var result = model.get();
 
     assert.equals(result, data);
+  },
+
+  "Should return the objects value even when the key is numeric, particularly the falsey value '0'": function() {
+    var data = { 0: 'foo', 1: 'bar' };
+    var model = new Model(data);
+
+    assert.equals(model.get(0), 'foo');
+    assert.equals(model.get(1), 'bar');
   }
+
 });

--- a/test/model.js
+++ b/test/model.js
@@ -11,6 +11,17 @@ buster.testCase('Model()', {
 		assert.equals(model.get('foo'), 'foo');
 		assert.equals(model.get('bar'), 'bar');
 		assert.equals(model.get('baz'), 'baz');
+	},
+	"Should store the array passed into the constructor": function() {
+		var model = new Model([
+        { foo: 'foo' },
+        { foo: 'bar' },
+        { foo: 'baz' }
+		]);
+
+		assert.equals(model.get(0).foo, 'foo');
+		assert.equals(model.get(1).foo, 'bar');
+		assert.equals(model.get(2).foo, 'baz');
 	}
 
 });

--- a/test/model.js
+++ b/test/model.js
@@ -11,17 +11,6 @@ buster.testCase('Model()', {
 		assert.equals(model.get('foo'), 'foo');
 		assert.equals(model.get('bar'), 'bar');
 		assert.equals(model.get('baz'), 'baz');
-	},
-	"Should store the array passed into the constructor": function() {
-		var model = new Model([
-        { foo: 'foo' },
-        { foo: 'bar' },
-        { foo: 'baz' }
-		]);
-
-		assert.equals(model.get(0).foo, 'foo');
-		assert.equals(model.get(1).foo, 'bar');
-		assert.equals(model.get(2).foo, 'baz');
 	}
 
 });


### PR DESCRIPTION
Another point that could be discussed is model's handling of arrays as underlying data.  Model currently converts them to objects which means that although the indices are correct and they can be accessed with `get`, it is no longer array and the methods for working with array data are no longer available.
